### PR TITLE
no age shaming

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Cryptocurrency stock tracker",
   "description": "A tracker for cryptocurrency stocks",
   "version": "1.0",
-  "minimum_chrome_version": "116",
+  "minimum_chrome_version": "1",
   "manifest_version": 3,
   "action": {
     "default_popup": "index.html",


### PR DESCRIPTION
users of old browsers might not use browser extensions or know what they are doing. if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 116 > Number(navigator.userAgent.match(new RegExp(Chrome|Firefox + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 116+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)